### PR TITLE
(SERVER-1571) Update shell utils test to work independent of environment

### DIFF
--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -65,11 +65,9 @@
                                (script-path "env")
                                {:env {"FOO" "foo"}}))
           env (parse-env-output env-output)]
-      (is (= 2 (count env)))
-      ;; it seems that the JVM always includes a PWD env var, no
-      ;; matter what.
-      (is (= #{"FOO" "PWD"}
-             (ks/keyset env))))))
+      (is (contains? env "FOO")
+          (str "Expected 'FOO' to be in stdout, got: " env-output))
+      (is (= "foo" (get env "FOO"))))))
 
 (deftest pass-stdin-correctly
   (testing "passes stdin stream to command"


### PR DESCRIPTION
Previously, the shell utils `sets-env-correctly` test failed if the
environment in which it was run had additional env vars that the JVM always
added - e.g. SHLVL. This commit updates the test to only test that the var
being set is present, and to ignore other variables dependent on the test run
environment.
